### PR TITLE
Fix eza module and improve fish shell integration

### DIFF
--- a/modules/common/shell/eza/default.nix
+++ b/modules/common/shell/eza/default.nix
@@ -18,15 +18,16 @@ in {
     home-manager.users.${username}.programs = mkIf (cfg.enable) ({
       eza = {
         enable = true;
+        icons = true;
       };
 
       fish = mkIf (cfg.enableFishIntegration) ({
         shellAliases = lib.mkDefault ({
-          ld = "eza -lD";
-          lf = "eza -lF --color=always | grep -v /";
-          lh = "eza -dl .* --group-directories-first";
+          ls = "eza";
           ll = "eza -al --group-directories-first";
-          ls = "eza -alF --color=always --sort=size | grep -v /";
+          la = "eza -la";
+          ld = "eza -lD";
+          lh = "eza -dl .* --group-directories-first";
           lt = "eza -al --sort=modified";
         });
       });

--- a/modules/common/shell/eza/default.nix
+++ b/modules/common/shell/eza/default.nix
@@ -22,14 +22,14 @@ in {
       };
 
       fish = mkIf (cfg.enableFishIntegration) ({
-        shellAliases = lib.mkDefault ({
+        shellAliases = {
           ls = "eza";
           ll = "eza -al --group-directories-first";
           la = "eza -la";
           ld = "eza -lD";
           lh = "eza -dl .* --group-directories-first";
           lt = "eza -al --sort=modified";
-        });
+        };
       });
     });
   };

--- a/modules/common/shell/fish/defaultConfig.nix
+++ b/modules/common/shell/fish/defaultConfig.nix
@@ -1,10 +1,5 @@
 { pkgs, ... }:
 {
-  programs.eza = {
-    enable = true;
-    icons = true;
-    enableAliases = true;
-  };
   programs.zoxide.enable = true;
   programs.fish = {
     enable = true;


### PR DESCRIPTION
This pull request fixes the eza module and improves the fish shell integration. The eza module now includes the `icons` option, and the fish shell aliases have been updated to include `ls`, `ll`, `la`, `ld`, and `lh`. Additionally, the `enableAliases` option has been removed from the eza module.