### PR TITLE
feat: add agent browser tooling

### DIFF
--- a/modules/home/development/utilities/agent-browser.nix
+++ b/modules/home/development/utilities/agent-browser.nix
@@ -1,0 +1,34 @@
+{
+  internal.homeModules.default =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.modules.development.agent-browser;
+      agent-browser = pkgs.writeShellApplication {
+        name = "agent-browser";
+        runtimeInputs = [ pkgs.chromium ];
+        text = ''
+          # Use Nixpkgs Chromium rather than downloading Chrome at runtime.
+          export AGENT_BROWSER_EXECUTABLE_PATH="${lib.getExe pkgs.chromium}"
+          exec ${lib.getExe pkgs.agent-browser} "$@"
+        '';
+      };
+    in
+    {
+      options.modules.development.agent-browser = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = config.modules.development.enable;
+          description = "Enable agent-browser";
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        home.packages = [ agent-browser ];
+      };
+    };
+}

--- a/modules/home/development/utilities/opencode.nix
+++ b/modules/home/development/utilities/opencode.nix
@@ -33,9 +33,33 @@
                 url = "https://executor.rodent.cc/mcp";
                 enabled = true;
               };
+
+              nixos = {
+                type = "local";
+                command = [
+                  "uvx"
+                  "mcp-nixos"
+                ];
+                enabled = true;
+              };
             };
           };
         };
+
+        xdg.configFile."fish/completions/opencode.fish".text = ''
+          function __opencode_completions
+              set -l args (commandline -opc)
+              set -e args[1]
+              set -l results (opencode --get-yargs-completions $args 2>/dev/null | grep -v '^\$0$')
+              if test (count $results) -eq 0
+                  __fish_complete_path (commandline -ct)
+              else
+                  printf '%s\n' $results
+              end
+          end
+
+          complete -c opencode -f -a '(__opencode_completions)'
+        '';
       };
     };
 }

--- a/modules/home/development/web/default.nix
+++ b/modules/home/development/web/default.nix
@@ -22,18 +22,9 @@
         home.packages = with pkgs; [
           nodejs_24
           unstable.bun
-          playwright-test
         ];
 
-        home.sessionPath = [
-          "${config.home.homeDirectory}/.cache/.bun/bin"
-        ];
-
-        programs.fish = {
-          shellAliases = {
-            playwright-cli = "playwright";
-          };
-        };
+        home.sessionPath = [ "${config.home.homeDirectory}/.cache/.bun/bin" ];
       };
     };
 }


### PR DESCRIPTION
## Summary
- add a Nix-native agent-browser utility backed by Nixpkgs Chromium
- remove the Playwright package and Fish alias from web tooling
- configure OpenCode NixOS MCP access and Fish completions

## Verification
- `nix flake check`
- `nix build .#nixosConfigurations.laptop.config.system.build.toplevel --no-link`
- opened and inspected `https://example.com` with the generated agent-browser wrapper