### PR TITLE
Configure Tailscale on desktop hosts

### DIFF
--- a/modules/home/desktop/apps/tailscale.nix
+++ b/modules/home/desktop/apps/tailscale.nix
@@ -1,0 +1,14 @@
+{
+  internal.homeModules.desktop =
+    {
+      config,
+      lib,
+      osConfig,
+      ...
+    }:
+    {
+      config = lib.mkIf config.modules.desktop.enable {
+        services.tailscale-systray.enable = osConfig.services.tailscale.enable;
+      };
+    };
+}

--- a/modules/hosts/gamer.nix
+++ b/modules/hosts/gamer.nix
@@ -29,6 +29,7 @@
       modules = {
         desktop.enable = true;
         desktop.plasma = true;
+        services.tailscale.enable = true;
       };
     };
   };

--- a/modules/hosts/laptop.nix
+++ b/modules/hosts/laptop.nix
@@ -34,6 +34,7 @@
         modules = {
           desktop.enable = true;
           desktop.plasma = true;
+          services.tailscale.enable = true;
         };
       };
     };

--- a/modules/nixos/services/tailscale.nix
+++ b/modules/nixos/services/tailscale.nix
@@ -1,0 +1,17 @@
+{
+  internal.nixosModules.default =
+    { config, lib, ... }:
+    let
+      cfg = config.modules.services.tailscale;
+    in
+    {
+      options.modules.services.tailscale.enable = lib.mkEnableOption "Tailscale";
+
+      config = lib.mkIf cfg.enable {
+        services.tailscale = {
+          enable = true;
+          openFirewall = true;
+        };
+      };
+    };
+}


### PR DESCRIPTION
## What changed

- add a reusable, disabled-by-default NixOS Tailscale module
- enable Tailscale and its firewall port on `gamer` and `laptop`
- enable Home Manager's official `tailscale-systray` service whenever the host's NixOS Tailscale service is enabled
- leave the WSL `work` host unchanged and disabled

## Why

Tailscale should be available on the two native desktop machines, including a desktop tray for user interaction, without enabling it on the work WSL host.

## Impact

After rebuilding `gamer` or `laptop`, the Tailscale daemon and user systray service will run. The host still needs to be authenticated with the intended tailnet if it has not been enrolled already.

## Validation

- `nix fmt`
- evaluated the host matrix: `gamer` and `laptop` have both Tailscale and the systray enabled; `work` has both disabled
- built `path:.#nixosConfigurations.gamer.config.system.build.toplevel`
- built `path:.#nixosConfigurations.laptop.config.system.build.toplevel`